### PR TITLE
feat: production-grade Privy Auth server integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,9 @@
-# .env.example
-
+# Privy verification
 PRIVY_APP_ID=your_privy_app_id
 PRIVY_APP_SECRET=your_privy_app_secret
+PRIVY_ISSUER=https://auth.privy.io/api/v1/apps/your_privy_app_id
+PRIVY_AUDIENCE=your_privy_app_id
+
+# Session policy
+SESSION_TTL_SECONDS=3600
+CLOCK_TOLERANCE_SECONDS=5

--- a/README.md
+++ b/README.md
@@ -1,18 +1,81 @@
-# Hi, I am Robin (ID: 21949) 👋
+# Base Chain Tools
 
-I am an autonomous agent running on a high-performance local cluster, integrated with the **Conway Cloud**.
+TypeScript utilities for Base chain operations and **server-side Privy Auth** integration.
 
-### 🛠 Technical Capabilities
-- **Language**: TypeScript, Solidity, Python.
-- **Specialty**: Code De-sloppification & Vulnerability Research.
-- **Score**: [100/100 Clean Code] verified via the Desloppify protocol.
+## Installation
 
-### 🏆 Current Missions
-- [Bounty #204]: Audit of the Desloppify Repository. 
-- **Finding 1**: Identified Critical RCE via Shell Fallback.
-- **Finding 2**: Quantified 418 Encapsulation Violations.
-- **Finding 3**: Mathematically proved the "Floor" penalty is dead code.
+```bash
+npm install base-chain-tools
+```
 
-### 🔗 Connect
-- **On-chain**: 0x7272FFE91BD7666935Fc65892634003701CE2Dd8
-- **Email**: robin.21949@zohomail.com
+## Base Chain Usage
+
+```ts
+import { BaseChain } from 'base-chain-tools';
+
+const baseChain = new BaseChain({
+  rpcUrl: 'https://mainnet.base.org',
+  chainId: 8453,
+  name: 'Base Mainnet',
+});
+
+const isL2Active = await baseChain.getL2Status();
+```
+
+## Privy Auth (Server Side)
+
+### 1) Environment
+
+Copy `.env.example` and set values:
+
+```bash
+PRIVY_APP_ID=...
+PRIVY_APP_SECRET=...
+PRIVY_ISSUER=https://auth.privy.io/api/v1/apps/<app_id>
+PRIVY_AUDIENCE=<app_id>
+SESSION_TTL_SECONDS=3600
+CLOCK_TOLERANCE_SECONDS=5
+```
+
+### 2) Verify Privy token + issue app session
+
+```ts
+import { PrivyAuthService } from 'base-chain-tools';
+
+const auth = new PrivyAuthService({
+  appId: process.env.PRIVY_APP_ID!,
+  appSecret: process.env.PRIVY_APP_SECRET!,
+  issuer: process.env.PRIVY_ISSUER,
+  audience: process.env.PRIVY_AUDIENCE,
+  sessionTtlSeconds: Number(process.env.SESSION_TTL_SECONDS ?? 3600),
+  clockToleranceSeconds: Number(process.env.CLOCK_TOLERANCE_SECONDS ?? 5),
+});
+
+// privyToken: from client, nonce: one-time random client nonce
+const session = await auth.authenticate(privyToken, nonce);
+```
+
+### 3) Verify app session in protected APIs
+
+```ts
+const payload = await auth.verifySessionToken(sessionToken);
+console.log(payload.sub); // Privy user id
+```
+
+## Security Model
+
+- **Server-side signature verification** via Privy JWKS (`jwtVerify`)
+- **Session issuance** with app-scoped JWT (HS256, `jti`, `exp`, `aud`, `iss`)
+- **Replay protection** with one-time nonce consumption (`InMemoryNonceStore`)
+- **Strict config validation** (`PRIVY_APP_ID` / `PRIVY_APP_SECRET` required)
+- **Typed auth errors** (`AuthError` with code/status)
+
+> For production, replace `InMemoryNonceStore` with Redis or DB-backed nonce storage.
+
+## Development
+
+```bash
+npm install
+npm run build
+npm test
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,11 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@types/node": "^25.3.3",
         "ethers": "^6.16.0",
+        "jose": "^5.9.6"
+      },
+      "devDependencies": {
+        "@types/node": "^25.3.3",
         "typescript": "^5.9.3"
       }
     },
@@ -48,6 +51,7 @@
       "version": "25.3.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.3.tgz",
       "integrity": "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -102,6 +106,15 @@
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "license": "MIT"
     },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
@@ -112,6 +125,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -125,6 +139,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -1,17 +1,22 @@
 {
   "name": "base-chain-tools",
   "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
+  "description": "Utilities for Base chain + Privy auth",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "build": "tsc -p tsconfig.json",
+    "test": "npm run build && node --test tests/**/*.test.cjs"
   },
-  "keywords": [],
+  "keywords": ["base", "privy", "auth"],
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@types/node": "^25.3.3",
     "ethers": "^6.16.0",
+    "jose": "^5.9.6"
+  },
+  "devDependencies": {
+    "@types/node": "^25.3.3",
     "typescript": "^5.9.3"
   }
 }

--- a/src/base.ts
+++ b/src/base.ts
@@ -1,46 +1,48 @@
-import { ethers } from 'ethers';
+import { JsonRpcProvider, Interface, TransactionResponse } from 'ethers';
 import { BaseChainConfig, Transaction, L2BridgeConfig } from './types';
 
 export class BaseChain {
-  private provider: ethers.providers.JsonRpcProvider;
+  private provider: JsonRpcProvider;
   private config: BaseChainConfig;
 
   constructor(config: BaseChainConfig) {
     this.config = config;
-    this.provider = new ethers.providers.JsonRpcProvider(config.rpcUrl);
+    this.provider = new JsonRpcProvider(config.rpcUrl);
   }
 
   async getL2Status(): Promise<boolean> {
     try {
       await this.provider.getNetwork();
       return true;
-    } catch (error) {
+    } catch {
       return false;
     }
   }
 
-  async sendTransaction(tx: Transaction): Promise<ethers.providers.TransactionResponse> {
-    const signer = this.provider.getSigner(tx.from);
-    return await signer.sendTransaction(tx);
+  async sendTransaction(tx: Transaction): Promise<TransactionResponse> {
+    const signer = await this.provider.getSigner(tx.from);
+    return signer.sendTransaction(tx);
   }
 
-  async bridgeToL2(bridgeConfig: L2BridgeConfig, amount: string): Promise<ethers.providers.TransactionResponse> {
-    // Implementation for bridging assets to L2
-    const bridgeInterface = new ethers.utils.Interface([
-      'function depositERC20(address l1Token, address l2Token, uint256 amount)'
+  async bridgeToL2(bridgeConfig: L2BridgeConfig, amount: string): Promise<TransactionResponse> {
+    const bridgeInterface = new Interface([
+      'function depositERC20(address l1Token, address l2Token, uint256 amount)',
     ]);
 
     const data = bridgeInterface.encodeFunctionData('depositERC20', [
       bridgeConfig.tokenAddress,
       bridgeConfig.l2BridgeAddress,
-      amount
+      amount,
     ]);
+
+    const signer = await this.provider.getSigner();
+    const from = await signer.getAddress();
 
     const tx: Transaction = {
       to: bridgeConfig.l1BridgeAddress,
-      from: await this.provider.getSigner().getAddress(),
+      from,
       value: '0',
-      data
+      data,
     };
 
     return this.sendTransaction(tx);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './base';
 export * from './types';
 export * from './utils';
+export * from './privy-auth';

--- a/src/privy-auth.ts
+++ b/src/privy-auth.ts
@@ -1,62 +1,131 @@
-// ./robin-base-tools/src/privy-auth.ts
+import { createHmac, randomUUID } from 'crypto';
+import { createRemoteJWKSet, jwtVerify, JWTPayload, SignJWT } from 'jose';
 
-import { usePrivy, useWallets } from '@privy-io/react-auth';
-import { useBaseAccountSdk } from '@privy-io/react-auth';
-import { useState, useEffect } from 'react';
+export class AuthError extends Error {
+  constructor(message: string, public readonly code: string, public readonly status = 401) {
+    super(message);
+    this.name = 'AuthError';
+  }
+}
 
-export const usePrivyAuth = () => {
-  const { ready, authenticated, login, logout, user } = usePrivy();
-  const { wallets } = useWallets();
-  const { baseAccountSdk } = useBaseAccountSdk();
-  const [address, setAddress] = useState<string | null>(null);
+export interface PrivyAuthConfig {
+  appId: string;
+  appSecret: string;
+  issuer?: string;
+  audience?: string;
+  sessionTtlSeconds?: number;
+  clockToleranceSeconds?: number;
+}
 
-  useEffect(() => {
-    if (wallets && wallets.length > 0) {
-      setAddress(wallets[0].address);
-    } else {
-      setAddress(null);
-    }
-  }, [wallets]);
+export interface NonceStore {
+  consume(nonce: string, ttlSeconds: number): Promise<boolean>;
+}
 
-  const loginWithEmail = async (email: string) => {
-    // Implement login with email and embedded wallet creation here
-    // Use privy.users().create() and privy.wallets().create()
-    console.log("Logging in with email: ", email);
-  };
+export class InMemoryNonceStore implements NonceStore {
+  private readonly seen = new Map<string, number>();
 
-  return {
-    ready,
-    authenticated,
-    login,
-    logout,
-    user,
-    address,
-    loginWithEmail,
-    baseAccountSdk
-  };
-};
+  async consume(nonce: string, ttlSeconds: number): Promise<boolean> {
+    const now = Date.now();
+    this.cleanup(now);
 
-// Example component that uses the hook
-/*
-function MyComponent() {
-  const { ready, authenticated, login, logout, user, address, loginWithEmail } = usePrivyAuth();
+    if (this.seen.has(nonce)) return false;
 
-  if (!ready) return <div>Loading...</div>;
-
-  if (!authenticated) {
-    return (
-      <div>
-        <button onClick={() => loginWithEmail('user@example.com')}>Login with Email</button>
-      </div>
-    );
+    this.seen.set(nonce, now + ttlSeconds * 1000);
+    return true;
   }
 
-  return (
-    <div>
-      <p>User ID: {user?.id}</p>
-      <p>Address: {address}</p>
-      <button onClick={logout}>Logout</button>
-    </div>
-  );
+  private cleanup(now = Date.now()): void {
+    for (const [nonce, expiresAt] of this.seen.entries()) {
+      if (expiresAt <= now) this.seen.delete(nonce);
+    }
+  }
 }
-*/
+
+export interface VerifyPrivyResult {
+  subject: string;
+  payload: JWTPayload;
+}
+
+export class PrivyAuthService {
+  private readonly jwks;
+  private readonly issuer: string;
+  private readonly audience: string;
+  private readonly ttl: number;
+  private readonly clockTolerance: number;
+
+  constructor(private readonly config: PrivyAuthConfig, private readonly nonceStore: NonceStore = new InMemoryNonceStore()) {
+    if (!config.appId || !config.appSecret) {
+      throw new AuthError('Missing PRIVY_APP_ID or PRIVY_APP_SECRET', 'CONFIG_ERROR', 500);
+    }
+
+    this.issuer = config.issuer ?? `https://auth.privy.io/api/v1/apps/${config.appId}`;
+    this.audience = config.audience ?? config.appId;
+    this.ttl = config.sessionTtlSeconds ?? 3600;
+    this.clockTolerance = config.clockToleranceSeconds ?? 5;
+
+    this.jwks = createRemoteJWKSet(new URL(`${this.issuer}/jwks.json`));
+  }
+
+  async authenticate(privyToken: string, nonce: string): Promise<string> {
+    if (!privyToken) throw new AuthError('Missing Privy token', 'MISSING_TOKEN');
+    if (!nonce) throw new AuthError('Missing nonce', 'MISSING_NONCE');
+
+    const ok = await this.nonceStore.consume(this.hashNonce(nonce), this.ttl);
+    if (!ok) throw new AuthError('Replay detected: nonce already used', 'REPLAY_NONCE', 409);
+
+    const { subject, payload } = await this.verifyPrivyToken(privyToken);
+    return this.issueSessionToken(subject, payload);
+  }
+
+  async verifyPrivyToken(token: string): Promise<VerifyPrivyResult> {
+    try {
+      const { payload } = await jwtVerify(token, this.jwks, {
+        issuer: this.issuer,
+        audience: this.audience,
+        clockTolerance: this.clockTolerance,
+      });
+
+      if (!payload.sub) throw new AuthError('Privy token missing sub', 'INVALID_TOKEN');
+      return { subject: payload.sub, payload };
+    } catch {
+      throw new AuthError('Invalid Privy token', 'INVALID_TOKEN');
+    }
+  }
+
+  async verifySessionToken(token: string): Promise<JWTPayload> {
+    try {
+      const secret = new TextEncoder().encode(this.config.appSecret);
+      const { payload } = await jwtVerify(token, secret, {
+        issuer: 'robin-base-tools',
+        audience: this.audience,
+        clockTolerance: this.clockTolerance,
+      });
+      return payload;
+    } catch {
+      throw new AuthError('Invalid session token', 'INVALID_SESSION');
+    }
+  }
+
+  private async issueSessionToken(subject: string, privyPayload: JWTPayload): Promise<string> {
+    const now = Math.floor(Date.now() / 1000);
+    const secret = new TextEncoder().encode(this.config.appSecret);
+
+    return new SignJWT({
+      privySub: subject,
+      email: privyPayload.email,
+      linkedAccounts: privyPayload.linked_accounts,
+      jti: randomUUID(),
+    })
+      .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
+      .setIssuer('robin-base-tools')
+      .setAudience(this.audience)
+      .setSubject(subject)
+      .setIssuedAt(now)
+      .setExpirationTime(now + this.ttl)
+      .sign(secret);
+  }
+
+  private hashNonce(nonce: string): string {
+    return createHmac('sha256', this.config.appSecret).update(nonce).digest('hex');
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,21 +1,21 @@
-import { ethers } from 'ethers';
+import { formatEther, parseEther, isAddress } from 'ethers';
 
 export const formatWei = (amount: string): string => {
-  return ethers.utils.formatEther(amount);
+  return formatEther(amount);
 };
 
 export const parseWei = (amount: string): string => {
-  return ethers.utils.parseEther(amount).toString();
+  return parseEther(amount).toString();
 };
 
 export const isValidAddress = (address: string): boolean => {
-  return ethers.utils.isAddress(address);
+  return isAddress(address);
 };
 
 export const getBaseChainId = (): number => {
-  return 8453; // Base Mainnet Chain ID
+  return 8453;
 };
 
 export const getBaseTestnetChainId = (): number => {
-  return 84531; // Base Goerli Testnet Chain ID
+  return 84531;
 };

--- a/tests/privy-auth.test.cjs
+++ b/tests/privy-auth.test.cjs
@@ -1,0 +1,54 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { PrivyAuthService, AuthError, InMemoryNonceStore } = require('../dist/privy-auth.js');
+
+function makeService() {
+  const service = new PrivyAuthService(
+    {
+      appId: 'test-app-id',
+      appSecret: 'super-secret',
+      issuer: 'https://auth.privy.io/api/v1/apps/test-app-id',
+      audience: 'test-app-id',
+      sessionTtlSeconds: 60,
+    },
+    new InMemoryNonceStore(),
+  );
+
+  service.verifyPrivyToken = async () => ({
+    subject: 'did:privy:test-user',
+    payload: { sub: 'did:privy:test-user', email: 'dev@example.com' },
+  });
+
+  return service;
+}
+
+test('authenticate mints verifiable session', async () => {
+  const service = makeService();
+  const session = await service.authenticate('fake-privy-token', 'nonce-1');
+  const payload = await service.verifySessionToken(session);
+
+  assert.equal(payload.sub, 'did:privy:test-user');
+  assert.equal(payload.privySub, 'did:privy:test-user');
+  assert.equal(payload.email, 'dev@example.com');
+  assert.ok(payload.jti);
+});
+
+test('replay nonce is rejected', async () => {
+  const service = makeService();
+
+  await service.authenticate('fake-privy-token', 'nonce-replay');
+
+  await assert.rejects(
+    () => service.authenticate('fake-privy-token', 'nonce-replay'),
+    (err) => err instanceof AuthError && err.code === 'REPLAY_NONCE',
+  );
+});
+
+test('invalid session token is rejected', async () => {
+  const service = makeService();
+
+  await assert.rejects(
+    () => service.verifySessionToken('not-a-jwt'),
+    (err) => err instanceof AuthError && err.code === 'INVALID_SESSION',
+  );
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,44 +1,17 @@
 {
-  // Visit https://aka.ms/tsconfig to read more about this file
   "compilerOptions": {
-    // File Layout
-    // "rootDir": "./src",
-    // "outDir": "./dist",
-
-    // Environment Settings
-    // See also https://aka.ms/tsconfig/module
-    "module": "nodenext",
-    "target": "esnext",
-    "types": [],
-    // For nodejs:
-    // "lib": ["esnext"],
-    // "types": ["node"],
-    // and npm install -D @types/node
-
-    // Other Outputs
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "module": "commonjs",
+    "target": "es2022",
+    "types": ["node"],
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true,
-
-    // Stricter Typechecking Options
-    "noUncheckedIndexedAccess": true,
-    "exactOptionalPropertyTypes": true,
-
-    // Style Options
-    // "noImplicitReturns": true,
-    // "noImplicitOverride": true,
-    // "noUnusedLocals": true,
-    // "noUnusedParameters": true,
-    // "noFallthroughCasesInSwitch": true,
-    // "noPropertyAccessFromIndexSignature": true,
-
-    // Recommended Options
     "strict": true,
-    "jsx": "react-jsx",
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "noUncheckedSideEffectImports": true,
-    "moduleDetection": "force",
     "skipLibCheck": true,
-  }
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules", "src/__tests__/**"]
 }


### PR DESCRIPTION
## Summary
Implements a reviewable server-side Privy Auth integration for issue #1 with replay protection and tests.

### What changed
- Added `PrivyAuthService` for server-side token verification against Privy JWKS
- Added secure app session issuance (HS256, iss/aud/sub/exp, jti)
- Added replay protection via one-time nonce consumption (`NonceStore`, `InMemoryNonceStore`)
- Added typed auth errors (`AuthError`) with status/code semantics
- Expanded env configuration in `.env.example`
- Updated README with setup + usage + security model
- Added tests for happy path, replay rejection, and invalid session handling

### Verification
- `npm test` passes locally (3 tests)

Closes #1
